### PR TITLE
Sqlite benchmark improvements

### DIFF
--- a/lib/database/sqflite.dart
+++ b/lib/database/sqflite.dart
@@ -30,6 +30,9 @@ class SqfliteDBImpl implements Benchmark {
       },
       version: 1,
     );
+    await db.rawQuery('PRAGMA journal_mode = WAL');
+    await db.rawQuery('PRAGMA synchronous = NORMAL');
+    await db.rawQuery('PRAGMA locking_mode = EXCLUSIVE');
     await db.delete(USER_TABLE); // delete all users in the table
   }
 

--- a/lib/database/sqflite_ffi.dart
+++ b/lib/database/sqflite_ffi.dart
@@ -33,6 +33,9 @@ class SqfliteFFIDBImpl implements Benchmark {
       },
       version: 1,
     );
+    await db.rawQuery('PRAGMA journal_mode = WAL');
+    await db.rawQuery('PRAGMA synchronous = NORMAL');
+    await db.rawQuery('PRAGMA locking_mode = EXCLUSIVE');
     await db.delete(USER_TABLE); // delete all users in the table
   }
 

--- a/lib/database/sqflite_ffi.dart
+++ b/lib/database/sqflite_ffi.dart
@@ -5,21 +5,24 @@ import 'package:db_benchmarks/interface/user.dart';
 import 'package:db_benchmarks/model/user.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:path/path.dart' as path;
 
-class SqfliteDBImpl implements Benchmark {
+class SqfliteFFIDBImpl implements Benchmark {
   late Database db;
   static const String USER_TABLE = "users";
 
   @override
-  String get name => 'Sqflite';
+  String get name => 'Sqflite (FFI)';
 
   @override
   Future<void> setUp() async {
     final dir = await getApplicationDocumentsDirectory();
-    final dbPath = path.join(dir.path, 'sqlite-sqflite.db');
+    final dbPath = path.join(dir.path, 'sqlite-ffi.db');
 
-    databaseFactory = null;
+    sqfliteFfiInit();
+
+    databaseFactory = databaseFactoryFfi;
 
     db = await openDatabase(
       dbPath,
@@ -139,7 +142,7 @@ class SqfliteDBImpl implements Benchmark {
     final dir = await getApplicationDocumentsDirectory();
     final files = dir
         .listSync()
-        .where((file) => file.path.toLowerCase().contains('sqlite-sqflite'));
+        .where((file) => file.path.toLowerCase().contains('sqlite-ffi'));
     int size = 0;
     for (FileSystemEntity file in files) {
       final stat = file.statSync();

--- a/lib/database/sqflite_json.dart
+++ b/lib/database/sqflite_json.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:db_benchmarks/interface/benchmark.dart';
+import 'package:db_benchmarks/interface/user.dart';
+import 'package:db_benchmarks/model/user.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:path/path.dart' as path;
+
+class SqfliteJsonDBImpl implements Benchmark {
+  late Database db;
+  static const String USER_TABLE = "users";
+
+  @override
+  String get name => 'Sqflite (JSON1)';
+
+  @override
+  Future<void> setUp() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final dbPath = path.join(dir.path, 'sqlite-json1.db');
+
+    sqfliteFfiInit();
+
+    databaseFactory = databaseFactoryFfi;
+
+    db = await openDatabase(
+      dbPath,
+      onCreate: (db, version) async {
+        await db.execute(
+          'CREATE TABLE $USER_TABLE (id TEXT PRIMARY KEY, createdAt TEXT, username TEXT, email TEXT, age INTEGER)',
+        );
+      },
+      version: 1,
+    );
+    await db.delete(USER_TABLE); // delete all users in the table
+  }
+
+  @override
+  Future<void> tearDown() async {
+    await db.close();
+  }
+
+  @override
+  Future<int> readUsers(List<User> users, bool optimise) async {
+    var s = Stopwatch()..start();
+    final ids = users.map((e) => e.id).toList();
+    await db.query(USER_TABLE,
+        where: "id IN (SELECT json_each.value FROM json_each(?))",
+        whereArgs: [jsonEncode(ids)]);
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> writeUsers(List<User> users, bool optimise) async {
+    var s = Stopwatch()..start();
+    String encoded = jsonEncode([for (var u in users) u.toMap()]);
+    await db.transaction((txn) async {
+      await txn.rawInsert(
+          """INSERT INTO $USER_TABLE(id, createdAt, username, email, age)
+          SELECT 
+            json_extract(json_each.value, '\$.id'),
+            json_extract(json_each.value, '\$.createdAt'),
+            json_extract(json_each.value, '\$.username'),
+            json_extract(json_each.value, '\$.email'),
+            json_extract(json_each.value, '\$.age')
+          FROM json_each(?)
+                  """, [encoded]);
+    });
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> deleteUsers(List<User> users, bool optimise) async {
+    var s = Stopwatch()..start();
+    final ids = users.map((e) => e.id).toList();
+    await db.delete(
+      USER_TABLE,
+      where: "id IN (SELECT json_each.value FROM json_each(?))",
+      whereArgs: [jsonEncode(ids)],
+    );
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  List<User> generateUsers(int count) {
+    return List.generate(
+      count,
+      (index) => UserModel(
+        id: index,
+        createdAt: DateTime.now(),
+        username: 'username',
+        email: 'email',
+        age: 25,
+      ),
+    );
+  }
+
+  @override
+  Future<int> getDbSize() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final files = dir
+        .listSync()
+        .where((file) => file.path.toLowerCase().contains('sqlite-json1'));
+    int size = 0;
+    for (FileSystemEntity file in files) {
+      final stat = file.statSync();
+      size += stat.size;
+    }
+    return size;
+  }
+}

--- a/lib/database/sqflite_json.dart
+++ b/lib/database/sqflite_json.dart
@@ -34,6 +34,9 @@ class SqfliteJsonDBImpl implements Benchmark {
       },
       version: 1,
     );
+    await db.rawQuery('PRAGMA journal_mode = WAL');
+    await db.rawQuery('PRAGMA synchronous = NORMAL');
+    await db.rawQuery('PRAGMA locking_mode = EXCLUSIVE');
     await db.delete(USER_TABLE); // delete all users in the table
   }
 

--- a/lib/database/sqlite_sync.dart
+++ b/lib/database/sqlite_sync.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:db_benchmarks/interface/benchmark.dart';
+import 'package:db_benchmarks/interface/user.dart';
+import 'package:db_benchmarks/model/user.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqlite3/sqlite3.dart';
+import 'package:sqlite3/open.dart';
+import 'package:path/path.dart' as path;
+
+class SqliteSyncDBImpl implements Benchmark {
+  late Database db;
+  static const String USER_TABLE = "users";
+
+  @override
+  String get name => 'Sqlite (Sync)';
+
+  @override
+  Future<void> setUp() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final dbPath = path.join(dir.path, 'sqlite-sync.db');
+
+    db = sqlite3.open(dbPath);
+
+    db.execute(
+        'CREATE TABLE IF NOT EXISTS $USER_TABLE (id TEXT PRIMARY KEY, createdAt TEXT, username TEXT, email TEXT, age INTEGER)');
+    db.execute(
+        'DELETE FROM $USER_TABLE WHERE 1'); // delete all users in the table
+  }
+
+  @override
+  Future<void> tearDown() async {
+    db.dispose();
+  }
+
+  @override
+  Future<int> readUsers(List<User> users, bool optimise) async {
+    var s = Stopwatch()..start();
+    final ids = users.map((e) => e.id).toList();
+    var stmt = db.prepare("SELECT * FROM $USER_TABLE WHERE id = ? LIMIT 1");
+    try {
+      for (var user in users) {
+        var results = stmt.execute([user.id]);
+      }
+    } finally {
+      stmt.dispose();
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> writeUsers(List<User> users, bool optimise) async {
+    var s = Stopwatch()..start();
+    db.execute('BEGIN');
+    var stmt = db
+        .prepare("""INSERT INTO $USER_TABLE(id, createdAt, username, email, age)
+              VALUES(?, ?, ?, ?, ?)""");
+    try {
+      for (var user in users) {
+        stmt.execute([
+          user.id,
+          user.createdAt.toIso8601String(),
+          user.username,
+          user.email,
+          user.age
+        ]);
+      }
+      db.execute('COMMIT');
+    } catch (e) {
+      db.execute('ROLLBACK');
+      rethrow;
+    } finally {
+      stmt.dispose();
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> deleteUsers(List<User> users, bool optimise) async {
+    var s = Stopwatch()..start();
+    db.execute('BEGIN');
+    var stmt = db.prepare("""DELETE FROM $USER_TABLE WHERE id = ?""");
+    try {
+      for (var user in users) {
+        stmt.execute([user.id]);
+      }
+      db.execute('COMMIT');
+    } catch (e) {
+      db.execute('ROLLBACK');
+      rethrow;
+    } finally {
+      stmt.dispose();
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  List<User> generateUsers(int count) {
+    return List.generate(
+      count,
+      (index) => UserModel(
+        id: index,
+        createdAt: DateTime.now(),
+        username: 'username',
+        email: 'email',
+        age: 25,
+      ),
+    );
+  }
+
+  @override
+  Future<int> getDbSize() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final files = dir
+        .listSync()
+        .where((file) => file.path.toLowerCase().contains('sqlite-sync'));
+    int size = 0;
+    for (FileSystemEntity file in files) {
+      final stat = file.statSync();
+      size += stat.size;
+    }
+    return size;
+  }
+}

--- a/lib/model/result.dart
+++ b/lib/model/result.dart
@@ -7,7 +7,7 @@ class Result {
   int dbSize = 0;
 
   String get databaseSize {
-    return (dbSize / 1024).toStringAsFixed(2);
+    return (dbSize / 1024 / 1024).toStringAsFixed(2);
   }
 
   Result(this.benchmark, this.optimised);

--- a/lib/view/benchmark_widget.dart
+++ b/lib/view/benchmark_widget.dart
@@ -4,6 +4,8 @@ import 'package:db_benchmarks/database/object_box.dart';
 import 'package:db_benchmarks/database/sembast.dart';
 import 'package:db_benchmarks/database/sqflite.dart';
 import 'package:db_benchmarks/database/sqflite_ffi.dart';
+import 'package:db_benchmarks/database/sqflite_json.dart';
+import 'package:db_benchmarks/database/sqlite_sync.dart';
 import 'package:db_benchmarks/interface/benchmark.dart';
 import 'package:db_benchmarks/model/result.dart';
 import 'package:db_benchmarks/runner/benchmark_runner_impl.dart';
@@ -42,6 +44,8 @@ class _BenchmarkWidgetState extends State<BenchmarkWidget> {
       HiveDBImpl(),
       SqfliteDBImpl(),
       SqfliteFFIDBImpl(),
+      SqfliteJsonDBImpl(),
+      SqliteSyncDBImpl(),
       ObjectBoxDBImpl(),
       IsarDBImpl(),
     ];

--- a/lib/view/benchmark_widget.dart
+++ b/lib/view/benchmark_widget.dart
@@ -38,6 +38,7 @@ class _BenchmarkWidgetState extends State<BenchmarkWidget> {
     ];
     optimisedRunners = [
       HiveDBImpl(),
+      SqfliteDBImpl(),
       ObjectBoxDBImpl(),
       IsarDBImpl(),
     ];

--- a/lib/view/benchmark_widget.dart
+++ b/lib/view/benchmark_widget.dart
@@ -3,6 +3,7 @@ import 'package:db_benchmarks/database/isar.dart';
 import 'package:db_benchmarks/database/object_box.dart';
 import 'package:db_benchmarks/database/sembast.dart';
 import 'package:db_benchmarks/database/sqflite.dart';
+import 'package:db_benchmarks/database/sqflite_ffi.dart';
 import 'package:db_benchmarks/interface/benchmark.dart';
 import 'package:db_benchmarks/model/result.dart';
 import 'package:db_benchmarks/runner/benchmark_runner_impl.dart';
@@ -33,12 +34,14 @@ class _BenchmarkWidgetState extends State<BenchmarkWidget> {
       HiveDBImpl(),
       SembasDBImpl(),
       SqfliteDBImpl(),
+      SqfliteFFIDBImpl(),
       ObjectBoxDBImpl(),
       IsarDBImpl(),
     ];
     optimisedRunners = [
       HiveDBImpl(),
       SqfliteDBImpl(),
+      SqfliteFFIDBImpl(),
       ObjectBoxDBImpl(),
       IsarDBImpl(),
     ];

--- a/lib/view/benchmark_widget.dart
+++ b/lib/view/benchmark_widget.dart
@@ -18,7 +18,7 @@ class BenchmarkWidget extends StatefulWidget {
 }
 
 class _BenchmarkWidgetState extends State<BenchmarkWidget> {
-  static const entrySteps = [10, 20, 50, 100, 200, 500, 1000, 2000];
+  static const entrySteps = [10, 20, 50, 100, 200, 500, 1000, 2000, 10000];
   late List<Benchmark> runners;
   late List<Benchmark> optimisedRunners;
   bool _optimised = false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,203 +5,224 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: e6dd5609f0945ef6bc72bdcd28af6eeabefef99a6d62b7790320133789217759
+      url: "https://pub.dev"
     source: hosted
     version: "38.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: c71e50e4e1674c9ffeaf053bb8d38e4a03b94d08af6a27fb352f3ff569becc44
+      url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: b003c3098049a51720352d219b0bb5f219b60fbfb68e7a4748139a06a5676515
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "29a03af98de60b4eb9136acd56608a54e989f6da238a80af739415b05589d6df"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: "5b7355c14258f5e7df24bad1566f7b991de3e54aeacfb94e1a65e5233d9739c1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "9aae031a54ab0beebc30a888c93e900d15ae2fd8883d031dbfbd5ebdb57f5a4c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.9"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: "56942f8114731d1e79942cd981cfef29501937ff1bccf4dbdce0273f31f13640"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: f4d6244cc071ba842c296cb1c4ee1b31596b9f924300647ac7a1445493471a3f
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: d7a9cd57c215bdf8d502772447aa6b52a8ab3f956d25d5fdea6ef1df2d2dad60
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: bdb1ab29be158c4784d7f9b7b693745a0719c5899e31c01112782bb1cb871e80
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "8aff82f9b26fd868992e5430335a9d773bfef01e1d852d7ba71bf4c5d9349351"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   dartx:
     dependency: transitive
     description:
       name: dartx
-      url: "https://pub.dartlang.org"
+      sha256: "45d7176701f16c5a5e00a4798791c1964bc231491b879369c818dd9a9c764871"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: "13a6ccf6a459a125b3fcdb6ec73bd5ff90822e071207c663bfd1f70062d51d18"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   flat_buffers:
     dependency: transitive
     description:
       name: flat_buffers
-      url: "https://pub.dartlang.org"
+      sha256: "23e2ced0d8e8ecdffbd9f267f49a668c74438393b9acaeac1c724123e3764263"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   flutter:
@@ -213,7 +234,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_test:
@@ -225,273 +247,312 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "4f4a162323c86ffc1245765cfe138872b8f069deb42f7dbb36115fa27f31469b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: c51b4fdfee4d281f49b8c957f1add91b815473597f76bcf07377987f66a55729
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: ae0b3d956ff324c6f8671f08dcb2dbd71c99cdbf2aa3ca63a14190c47aa6679c
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   hive:
     dependency: "direct main"
     description:
       name: hive
-      url: "https://pub.dartlang.org"
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: db3060f22889f3d9d55f6a217565486737037eec3609f7f3eca4d0c67ee0d8a0
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "0d4c73c3653ab85bf696d51a9657604c900a370549196a91f33e4c39af760852"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   isar:
     dependency: "direct main"
     description:
       name: isar
-      url: "https://pub.dartlang.org"
+      sha256: d1863d38b3bd3acb7e040414a8d1d98d708c4621db3c09980b7a310b63460e2c
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.0"
   isar_flutter_libs:
     dependency: "direct main"
     description:
       name: isar_flutter_libs
-      url: "https://pub.dartlang.org"
+      sha256: "581d1352b41205617cc1d124e75baf747650803337c734d2352d5eef7b9cb26b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.0"
   isar_generator:
     dependency: "direct dev"
     description:
       name: isar_generator
-      url: "https://pub.dartlang.org"
+      sha256: "81a6f2d3d2379672b398f4f8779f7cce02675809c7ed72535a9093b8ec945bc1"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.0"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: cb314f00b2488de7bc575207e54402cd2f92363f333a7933fd1b0631af226baa
+      url: "https://pub.dev"
     source: hosted
     version: "4.6.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "293ae2d49fd79d4c04944c3a26dfd313382d5f52e821ec57119230ae16031ad4"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: dab22e92b41aa1255ea90ddc4bc2feaf35544fd0728e209638cad041a6e3928a
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   objectbox:
     dependency: "direct main"
     description:
       name: objectbox
-      url: "https://pub.dartlang.org"
+      sha256: a5c743bd0f5042058d719190d28fb358e154a83ff3e97c01c185c7dea02d488f
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.1"
   objectbox_flutter_libs:
     dependency: "direct main"
     description:
       name: objectbox_flutter_libs
-      url: "https://pub.dartlang.org"
+      sha256: "60c331d9aa6645e40dddce4ec5d7366f2549e99f1cd0ff0a5a467bace6678330"
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.1"
   objectbox_generator:
     dependency: "direct dev"
     description:
       name: objectbox_generator
-      url: "https://pub.dartlang.org"
+      sha256: bc9f5f9efc23fb0e4a56d487bc9d8e6c8b93e66071411c33d2fef0b478ed531c
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
-      url: "https://pub.dartlang.org"
+      sha256: "050e8e85e4b7fecdf2bb3682c1c64c4887a183720c802d323de8a5fd76d372dd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.11"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      url: "https://pub.dartlang.org"
+      sha256: "482308523e21a90eccb2146fefb2ae9ea392740c539e35d1cd34916d2ee5492b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.19"
   path_provider_ios:
     dependency: transitive
     description:
       name: path_provider_ios
-      url: "https://pub.dartlang.org"
+      sha256: "03d639406f5343478352433f00d3c4394d52dac8df3d847869c5e2333e0bbce8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.11"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: ab0987bf95bc591da42dffb38c77398fc43309f0b9b894dcc5d6f40c4b26c379
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.7"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
-      url: "https://pub.dartlang.org"
+      sha256: "2a97e7fbb7ae9dcd0dfc1220a78e9ec3e71da691912e617e8715ff2a13086ae8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "27dc7a224fcd07444cb5e0e60423ccacea3e13cf00fc5282ac2c918132da931d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: a34ecd7fb548f8e57321fd8e50d865d266941b54e6c3b7758cf8f37c24116905
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.7"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "075f927ebbab4262ace8d0b283929ac5410c0ac4e7fc123c76429564facfb757"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "816c1a640e952d213ddd223b3e7aafae08cd9f8e1f6864eed304cc13b0272b07"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   sembast:
     dependency: "direct main"
     description:
       name: sembast
-      url: "https://pub.dartlang.org"
+      sha256: b0d14c6844615aafbe5eb13e97a75fad97a927051cdea2d614811fc5f3b0be8f
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0+1"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: "8ec607599dd0a78931a5114cdac7d609b6dbbf479a38acc9a6dba024b2a30ea0"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "6db16374bc3497d21aa0eebe674d3db9fdf82082aac0f04dc7b44e4af5b08afc"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   sky_engine:
@@ -503,142 +564,186 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: "00f8b6b586f724a8c769c96f1d517511a41661c0aede644544d8d86a1ab11142"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   sqflite:
     dependency: "direct main"
     description:
       name: sqflite
-      url: "https://pub.dartlang.org"
+      sha256: "51c09d414ca74b1cd4a5880d63763ebd2033a4fc6d921708c7c1e98c603735d4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2+1"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      url: "https://pub.dartlang.org"
+      sha256: bfd6973aaeeb93475bc0d875ac9aefddf7965ef22ce09790eb963992ffc5183f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+2"
+  sqflite_common_ffi:
+    dependency: "direct main"
+    description:
+      name: sqflite_common_ffi
+      sha256: e435a9dcd0ca79ba6aea677468e6f7cb8859891294a8f34226685f2cf2002ea2
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1+1"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: db6350456720a4088a364bbe02052d43056a5ffbd4816fe9d28310dcfbe0dc05
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.1"
+  sqlite3_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlite3_flutter_libs
+      sha256: ebfdab73610bbd2ec01d8f367b7a1b49ad3a01f398df436f283e4063173ceb7b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.12"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: ed464977cb26a1f41537e177e190c67223dbd9f4f683489b6ab2e5d211ec564e
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
-      url: "https://pub.dartlang.org"
+      sha256: a7f0790927c0806ae0d5eb061c713748fa6070ef0037e391a2d53c3844c09dc2
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0+2"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.16"
   time:
     dependency: transitive
     description:
       name: time
-      url: "https://pub.dartlang.org"
+      sha256: "28e2673ca9d4e1d6baa2a5d726a170e4feed86732ee983fd671f7db8404fa9db"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: c386d07d7f5efc613479a7c4d9d64b03710b03cfaa7e8ad5f2bfb295a1f0dfad
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: e42dfcc48f67618344da967b10f62de57e04bae01d9d3af4c2596f3712a88c99
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "3a969ddcc204a3e34e863d204b29c0752716f78b6f9cc8235083208d268a4ccd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: "4658d864d83cdaedcbf3e65ad93b71880a3e8c9ee1ff15d855f88fb2da66cb8a"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.2"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: "060b6e1c891d956f72b5ac9463466c37cce3fa962a921532fc001e86fe93438e"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0+1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.16.2 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=2.8.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   objectbox_flutter_libs: any
   isar: ^2.5.0
   isar_flutter_libs: ^2.5.0
+  sqflite_common_ffi: ^2.2.1+1
+  sqlite3_flutter_libs: ^0.5.12
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <objectbox_flutter_libs/objectbox_flutter_libs_plugin.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   IsarFlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("IsarFlutterLibsPlugin"));
   ObjectboxFlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ObjectboxFlutterLibsPlugin"));
+  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,10 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   isar_flutter_libs
   objectbox_flutter_libs
+  sqlite3_flutter_libs
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)
@@ -15,3 +19,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)


### PR DESCRIPTION
The current sqflite benchmarks are missing some basic optimizations, which make it much slower than what it could be.

Some basic optimizations:

1. Wrap writes in a transaction (similar to the isar benchmarks) - 1.5-2x speedup for write and delete.
2. Add an optimized mode that uses batches: another 3-10x speedup for reads and writes.
3. Use [sqflite_common_ffi](https://pub.dev/packages/sqflite_common_ffi) -> another 2-10x speedup on Android, probably les significant on iOS. Does increase app size a little.

Then I also have some more advanced options - as separate benchmarks since it does make the code more complicated.

1. Using SQLite's JSON1 extension with sqflite -> gives more efficient batching, especially for `id IN ?` type queries, at the cost of more complicated queries. Only available when using the FFI version.
2. Use the low-level synchronous APIs of [sqlite3](https://pub.dev/packages/sqlite3). These would block the main event loop if queries are slow, and should probably be used in a separate isolate (although ObjectBox also uses a synchronous API and probably has the same caveats).

The synchronous sqlite3 read and delete benchmarks could be made faster by using the same JSON1 extension as for sqflite - should get the same performance.

I'm including screenshots of the benchmarks on an Android phone (OnePlus Nord N10, Android 11). Also included the original Sqflite one here for comparison.

![image](https://user-images.githubusercontent.com/94081/219346826-2f82d693-24f2-4733-a7ab-c443b8897c26.png)

![image](https://user-images.githubusercontent.com/94081/219346945-68644396-8c3c-45f7-94cc-e7c165b3ef01.png)

_Update:_

Also configured `journal_mode = WAL`, `synchronous = NORMAL` and `locking_mode = EXCLUSIVE`. These are all options that should work well for any mobile app. This gives another speed up of up to 2x in some of the benchmarks (see https://phiresky.github.io/blog/2020/sqlite-performance-tuning/).

Wrapping reads in a transaction also added some improvement, but only when the above options were not set (reduces the number of locks required, but not relevant with `WAL` and `locking_mode = EXCLUSIVE`). `synchronous = NORMAL` would likely have a performance improvement for many small transactions, but less significant for large batches.

My screenshots don't include these optimizations yet.
